### PR TITLE
修正、公開制限

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -49,7 +49,7 @@
   }
   .text_area {
     width: 70%;
-    height: 500px;
+    
     background-color: white;
     margin: 0 auto;
   }
@@ -270,7 +270,7 @@
   }
   .text_area {
     width: 70%;
-    height: 500px;
+    
     margin: 0 auto;
     background-color: white;
   }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -65,6 +65,10 @@ class ProfilesController < ApplicationController
 
   end
 
+  def pass
+    
+  end
+
   private
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,21 +32,26 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @profile = @user.profile
-    
-    # 該当ユーザーのタグ名をpluckメソッドを使ってtag_nameカラムで取得。
-    @tags = @profile.tags.pluck(:tag_name)
-    
-    # profileのtagを持ってくるように修正しました（もしかして@tagは使っていない？）
-    # @tag = Tag.find(params[:id])
-    @tag = @profile.tags
-    
-    # pvカウント
-    if params[:pv_link] == "pv++" && @user.id != current_user.id
-      @profile.pv_count += 1
-      @profile.update(pv_count: @profile.pv_count)
-      redirect_to user_path(@user.id)
+    # パスワードが一致するか。パスワードカラム追加後変更
+    if @profile.phone == params[:phone]
+      # 該当ユーザーのタグ名をpluckメソッドを使ってtag_nameカラムで取得。
+      @tags = @profile.tags.pluck(:tag_name)
+      
+      # profileのtagを持ってくるように修正しました（もしかして@tagは使っていない？）
+      # @tag = Tag.find(params[:id])
+      @tag = @profile.tags
+      
+      # pvカウント
+      if params[:pv_link] == "pv++" && @user.id != current_user.id
+        @profile.pv_count += 1
+        @profile.update(pv_count: @profile.pv_count)
+        redirect_to user_path(@user.id)
+      end
+    else
+      # 何故かusers_pathなのにpass画面のままですが、それでもいいかなと思います
+      redirect_back(fallback_location: users_path)
+      flash[:notice] = "パスワードが一致しませんでした。" 
     end
-
     # タグ全部取ってきます
     @tag_list = Tag.all
 

--- a/app/views/comments/show.html.haml
+++ b/app/views/comments/show.html.haml
@@ -2,6 +2,8 @@
   新着コメントがあります
   %br
   ※ 公開するコメントにチェックして下さい。
+  .back.mt-3
+    = link_to '戻る', :back
 .d-flex.justify-content-center.mt-5
   = form_with model: @comment,url: user_comment_path, method: "patch", class: "comment_check ",local: true do |f|
     %label{for: "all"}

--- a/app/views/profiles/pass.html.haml
+++ b/app/views/profiles/pass.html.haml
@@ -1,0 +1,11 @@
+.form-group
+  = form_with url: users_show_path(id: params[:profile_id]), class: "form-group",local: true do |f|
+    .form-group
+      %label.col-form-label{for: "pass-text"} pass:
+      -#仮でプロフィールのphoneにしてあります,パスワードカラム作成プロフィール登録にパスワード項目の追加が必要です。
+      = f.text_field :phone, id: "pass-text" 
+    .form_submit
+      = f.submit "Send", class: "btn btn-primary"
+.back.mt-3
+  = link_to '戻る', 'javascript:history.back()'
+  

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -112,15 +112,17 @@
               = @user.email
             .modal-footer
               %button.btn.btn-secondary{"data-dismiss" => "modal", :type => "button"} Close
-      %h3.d-flex.justify-content-center.mt-3.mobile_name
-        = @profile.family_name
-      %h3.d-flex.justify-content-center.mt-3.mobile_name
-        = @profile.first_name
-      %h5.d-flex.justify-content-center.mt-3.mobile_birth
-        = @profile.prefecture.name
-      %img.prof_image.mt-2.mobile_img{:height => "auto", :src => "#{@profile.avatar}", :width => "40%"}
-        %p.text-break.ml-5.mr-5.pt-5.mobile_text 
-          = @profile.introduction
+      = link_to profile_pass_path(params[:id]) do
+        %h3.d-flex.justify-content-center.mt-3.mobile_name
+          = @profile.family_name
+        %h3.d-flex.justify-content-center.mt-3.mobile_name
+          = @profile.first_name
+        %h5.d-flex.justify-content-center.mt-3.mobile_birth
+          = @profile.prefecture.name
+        %img.prof_image.mt-2.mobile_img{:height => "auto", :src => "#{@profile.avatar}", :width => "40%"}
+          %p.text-break.ml-5.mr-5.mb-3.pt-5.mobile_text 
+            = @profile.avatar_about
+          
   .slider.mt-5.d-flex.justify-content-center
   
     
@@ -142,27 +144,32 @@
       - if @profile.hp.present?
         = link_to "HP", @profile.hp, class: 'btn btn-primary ml-2 mt-1',  rel: "noopener noreferrer", target: "_blank"
         
-    .prof_all.d-flex
-      %img.prof_image.mt-3.ml-2.mb-2{:src => "#{@profile.avatar}"}
-      .prof_contents
-        .prof.d-flex
-          %h3.mt-3.ml-3
-            = @profile.family_name
-          %h3.mt-3.ml-1
-            = @profile.first_name
-          %h5.mt-3.ml-3
-            = @profile.prefecture.name
-          %h5.mt-3.ml-3
-            = @profile.birth_date
-        .introduction
-          %p.ml-5.mr-5.pt-3 
-            = @profile.introduction
+    = link_to profile_pass_path(params[:id]) do
+      .prof_all.d-flex
+        %img.prof_image.mt-3.ml-2.mb-2{:src => "#{@profile.avatar}"}
+        .prof_contents
+          .prof.d-flex
+            %h3.mt-3.ml-3
+              = @profile.family_name
+            %h3.mt-3.ml-1
+              = @profile.first_name
+            %h5.mt-3.ml-3
+              = @profile.prefecture.name
+            %h5.mt-3.ml-3
+              = @profile.birth_date
+          .introduction
+            %p.ml-5.mr-5.pt-3 
+              = @profile.avatar_about
 
   .mt-5.text_area
-    %p.text-break.ml-5.mr-5.pt-5 mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
+    %p.text-break.ml-5.mr-5.pt-3.pb-3
+      = @profile.introduction
   
   .comment_field
-    
+    コメント
+    - if @comments.blank?
+      %br
+      まだコメントはありません。
     - @comments.each do |comment|
       - if comment.check == (1) && comment.reply_id.blank?
         .comment_info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,10 @@ Rails.application.routes.draw do
   end
   resources :profiles do
     patch 'color'
+    get 'pass'
   end
-  
+
+  post "users/show" => "users#show"
 
 
 end


### PR DESCRIPTION
見た目少し修正

・公開制限
pass画面実装、パスワード入力で詳細画面へ
パスワードカラムの代わりに仮でプロフィールのphoneにしています。
pass画面の見た目はまだ整えていません。
自分のページでもパスワード入力が必要になっているため後日修正予定。