### PR TITLE
profilesテーブルにpassword_digestカラム追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -117,6 +117,8 @@ class ProfilesController < ApplicationController
       :remove_image,
       :remove_sub_image,
       :remove_avatar,
+      :password,
+      :password_confirmation,
 
       images_attributes: [:src]
     ).merge(user_id: current_user.id)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -73,5 +73,7 @@ class Profile < ApplicationRecord
     
   end
 
+  # gem bcrypt関連
+  has_secure_password
 
 end

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -33,6 +33,13 @@
     .form-group
       = f.label "名前（ふりがな）"
       = f.text_field :family_name_kana, class: "form-control"
+    -# passwordの暗号化。password_confirmationはあってもなくてもOK。
+    .form-group
+      = f.label "password"
+      = f.text_field :password, class: "form-control"
+    -# .form-group
+    -#   = f.label "password確認"
+    -#   = f.text_field :password_confirmation, class: "form-control"
     .form-group
       = f.label "郵便番号 ※半角数字のみ（ハイフンなし）"
       -# 半角数字のみ（ハイフンなし）

--- a/db/migrate/20201102131034_add_password_to_profiles.rb
+++ b/db/migrate/20201102131034_add_password_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddPasswordToProfiles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :profiles, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_141823) do
+ActiveRecord::Schema.define(version: 2020_11_02_131034) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2020_10_21_141823) do
     t.text "avatar_about"
     t.string "color"
     t.integer "pv_count", null: false
+    t.string "password_digest"
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 


### PR DESCRIPTION
# what
- profilesテーブルにpassword_digestカラム追加
- gem bcryptでpassword暗号化
- gemの特性上password_digestというカラム名で追加していますが、実際に登録する際はpasswordというカラム名でOKです
# why
- 認証機能実装にむけて