### PR TITLE
公開制限

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,8 +32,8 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @profile = @user.profile
-    # パスワードが一致するか。パスワードカラム追加後変更 パスワード設定してないのも追加予定
-    if @profile.phone == params[:phone] || @user.id == current_user.id
+    # パスワードが一致するか。 パスワード設定してないのも追加予定
+    if @user.id == current_user.id || @profile.authenticate(params[:password])
       # 該当ユーザーのタグ名をpluckメソッドを使ってtag_nameカラムで取得。
       @tags = @profile.tags.pluck(:tag_name)
       

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,5 +1,5 @@
 = form_with model: [@user,@comment], class: "was-validated",local: true do |f|
   .form-group.mt-4
-    = f.text_area :comment, id: "exampleFormControlTextarea1", class: "form-control form-control-lg col-sm-10 m-auto", placeholder: "新規コメントはこちら"
+    = f.text_area :comment, id: "exampleFormControlTextarea1", class: "form-control form-control-lg col-sm-8 m-auto", placeholder: "新規コメントはこちら"
   .col-auto.d-flex.justify-content-center.mt-3
     = f.submit "コメント", class: "btn btn-primary mb-4"

--- a/app/views/comments/show.html.haml
+++ b/app/views/comments/show.html.haml
@@ -1,9 +1,11 @@
-.comment_select.mt-5
-  新着コメントがあります
-  %br
-  ※ 公開するコメントにチェックして下さい。
-  .back.mt-3
-    = link_to '戻る', :back
+.jumbotron.jumbotron-fluid.p-4
+  .container
+    .back.col.text-right
+      = link_to '戻る', :back
+    .comment_select.mt-5
+      新着コメントがあります
+      %br
+      ※ 公開するコメントにチェックして下さい。
 .d-flex.justify-content-center.mt-5
   = form_with model: @comment,url: user_comment_path, method: "patch", class: "comment_check ",local: true do |f|
     %label{for: "all"}

--- a/app/views/profiles/pass.html.haml
+++ b/app/views/profiles/pass.html.haml
@@ -10,7 +10,6 @@
   = form_with url: users_show_path(id: params[:profile_id]), class: "form-group",local: true do |f|
     .form-group.row
       %label.col-form-label{for: "pass-text"} password:
-      -#仮でプロフィールのphoneにしてあります,パスワードカラム作成プロフィール登録にパスワード項目の追加が必要です。
-      = f.text_field :phone, id: "pass-text", class: "form-control input-lg "
+      = f.text_field :password, id: "pass-text", class: "form-control input-lg "
     .form_submit.text-center
       = f.submit "Send", class: "btn btn-primary"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -124,15 +124,11 @@
             = @profile.avatar_about
           
   .slider.mt-5.d-flex.justify-content-center
-  
-    
     %img.top_image{:src => "#{@profile.image}"}
     - if @profile.sub_image.present?
       = link_to vr_users_path(user_id: params[:id]) do
         %img.top_image{:src => "#{@profile.sub_image}"}
-  
-  
-    
+
   .mt-5.mb-5.profile
     .d-flex.justify-content-center
       %button.btn.btn-primary.mt-1{"data-target" => "#exampleModal", "data-toggle" => "modal", :type => "button"}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,12 +116,12 @@ ActiveRecord::Schema.define(version: 2020_11_02_131034) do
     t.string "twitter"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "color"
     t.string "sub_image"
     t.string "catch_copy"
     t.string "avatar_title"
     t.string "avatar_catch_copy"
     t.text "avatar_about"
-    t.string "color"
     t.integer "pv_count", null: false
     t.string "password_digest"
     t.index ["user_id"], name: "index_profiles_on_user_id"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_131034) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "name", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -143,6 +144,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_131034) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "nickname", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
・見た目、詳細画面等と統一するため変更。
・宗友さんに追加していただいたpasswordカラムでの認証。
・詳細画面に行くリンクは　profile_pass_path(params[:id]) (※idの記述は変更する必要があるかもしれません。)こちらでお願いします。
　passアクションで、自分の詳細ページに行く時はpass画面飛ばして行けるようにしてありますので全て↑のpathでおkです。