### PR TITLE
マイページの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,3 +109,6 @@ group :development, :test do
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
 end
+
+gem 'kaminari'
+gem 'bootstrap4-kaminari-views'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       jquery-rails (~> 4.2, >= 4.2.0)
       moment-timezone-rails (~> 1.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
+    bootstrap4-kaminari-views (1.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     byebug (11.1.3)
     capistrano (3.14.1)
@@ -212,6 +215,18 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -406,6 +421,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   bootstrap
   bootstrap4-datetime-picker-rails
+  bootstrap4-kaminari-views
   byebug
   capistrano
   capistrano-bundler
@@ -427,6 +443,7 @@ DEPENDENCIES
   jquery-datetimepicker-rails
   jquery-rails
   jquery-ui-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick
   momentjs-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,6 +57,15 @@ class UsersController < ApplicationController
     # タグ全部取ってきます
     @tag_list = Tag.all
 
+    # @store_profiles = @user.store_profiles.order("created_at DESC").page(params[:page]).per(3)
+    # @item_profiles = @user.item_profiles.order("created_at DESC").page(params[:page]).per(3)
+    # @service_profiles = @user.service_profiles.order("created_at DESC").page(params[:page]).per(3)
+    # @event_profiles = @user.event_profiles.order("created_at DESC").page(params[:page]).per(3)
+    @store_profiles = @user.store_profiles.order("created_at DESC")
+    @item_profiles = @user.item_profiles.order("created_at DESC")
+    @service_profiles = @user.service_profiles.order("created_at DESC")
+    @event_profiles = @user.event_profiles.order("created_at DESC")
+
   end
   
   

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -12,424 +12,186 @@
         さん
     %p
       My Profile 情報編集画面
-.container
-  -# タブ切り替えにしています
-  %ul.nav.nav-tabs.nav-justified{role: "tablist", style: "width: auto; overflow-y: scroll"}
-    %li.nav-item
-      %a#item1-tab.nav-link.active{"aria-controls" => "item1", "aria-selected" => "true", "data-toggle" => "tab", href: "#item1", role: "tab"} 人物
     - if current_user.card
-      %li.nav-item
-        %a#item2-tab.nav-link{"aria-controls" => "item2", "aria-selected" => "false", "data-toggle" => "tab", href: "#item2", role: "tab"} 店舗
-      %li.nav-item
-        %a#item3-tab.nav-link{"aria-controls" => "item3", "aria-selected" => "false", "data-toggle" => "tab", href: "#item3", role: "tab"} 商品
-      %li.nav-item
-        %a#item4-tab.nav-link{"aria-controls" => "item4", "aria-selected" => "false", "data-toggle" => "tab", href: "#item4", role: "tab"} サービス
-      %li.nav-item
-        %a#item5-tab.nav-link{"aria-controls" => "item5", "aria-selected" => "false", "data-toggle" => "tab", href: "#item5", role: "tab"} イベント
-  .tab-content
-    #item1.tab-pane.fade.show.active{"aria-labelledby" => "item1-tab", role: "tabpanel"}
-      %label.mt-3.mb-4(for="") ---プロフィール---
-      = form_with(model: @profile, class: "form-horizontal mb-3", local: true) do |f|
-        = render 'layouts/error_messages', model: f.object
-        .form-group
-          = f.label "メイン写真を設定する"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.image?
-            = image_tag current_user.profile.image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :image, class: "form-control-file"
-          %p
-            = f.check_box :remove_image #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          = f.label :VR, "VR画像を設定する"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.sub_image?
-            = image_tag current_user.profile.sub_image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :sub_image, class: "form-control-file"
-          %p
-            = f.check_box :remove_sub_image #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          -# カラム追加済み
-          = f.label "キャッチコピー"
-          = f.text_field :catch_copy, class: "form-control"
-        .form-group
-          = f.label "名字"
-          = f.text_field :first_name, class: "form-control"
-        .form-group
-          = f.label "名前"
-          = f.text_field :family_name, class: "form-control"
-        .form-group
-          = f.label "名字（ふりがな）"
-          = f.text_field :first_name_kana, class: "form-control"
-        .form-group
-          = f.label "名前（ふりがな）"
-          = f.text_field :family_name_kana, class: "form-control"
-        .form-group
-          = f.label "password"
-          = f.text_field :password, class: "form-control"
-        .form-group
-          = f.label "郵便番号 ※半角数字のみ（ハイフンなし）"
-          -# 半角数字のみ（ハイフンなし）
-          = f.text_field :post_code, class: "form-control", pattern: "^[0-9]+$"
-        .form-group
-          = f.label "都道府県"
-          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: "form-control"}
-        .form-group
-          = f.label "市区町村"
-          = f.text_field :city, class: "form-control"
-        .form-group
-          = f.label "以降の住所"
-          = f.text_field :address_number, class: "form-control"
-        .form-group
-          = f.label "建物"
-          = f.text_field :building, class: "form-control"
-        .form-group
-          = f.label "電話番号 ※半角数字のみ（ハイフンなし）"
-          = f.text_field :phone, class: "form-control", pattern: "^[0-9]+$"
-        .form-group
-          = f.label "生年月日"
-          = f.date_select :birth_date, {year_format: ->year { "#{Date.new(year, 12, 31).jisx0301.split('.').first}(#{year})" },use_month_numbers: true, start_year: 1950, end_year: Time.now.year, prompt: "---"}, {class: "form-control"}
-        .form-group
-          = f.label "小学校"
-          = f.text_field :primary_school, class: "form-control"
-        .form-group
-          = f.label "中学校"
-          = f.text_field :Junior_high_school, class: "form-control"
-        .form-group
-          = f.label "高校"
-          = f.text_field :high_school, class: "form-control"
-        .form-group
-          = f.label "大学"
-          = f.text_field :university, class: "form-control"
-        .form-group
-          = f.label "大学院"
-          = f.text_field :graduate_school, class: "form-control"
-        .form-group
-          = f.label "専門学校"
-          = f.text_field :vocational_school, class: "form-control"
-        .form-group
-          = f.label "その他学歴"
-          = f.text_field :other_school, class: "form-control"
-        .form-group
-          = f.label "職歴１"
-          = f.text_field :first_career, class: "form-control"
-        .form-group
-          = f.label "職歴２"
-          = f.text_field :second_career, class: "form-control"
-        .form-group
-          = f.label "職歴３"
-          = f.text_field :third_career, class: "form-control"
-        .form-group
-          = f.label "職歴４"
-          = f.text_field :fourth_career, class: "form-control"
-        .form-group
-          = f.label "職歴５"
-          = f.text_field :last_career, class: "form-control"
-        .form-group
-          = f.label "FaceBook"
-          = f.text_field :facebook, class: "form-control"
-        .form-group
-          = f.label "Twitter"
-          = f.text_field :twitter, class: "form-control"
-        .form-group
-          = f.label "ホームページ"
-          = f.text_field :hp, class: "form-control"
+      = link_to("店舗情報投稿", new_store_profile_path, { class: "btn btn-info mt-3" })
+      = link_to("商品情報投稿", new_item_profile_path, { class: "btn btn-info mt-3" })
+      = link_to("サービス情報投稿", new_service_profile_path, { class: "btn btn-info mt-3" })
+      = link_to("イベント情報投稿", new_event_profile_path, { class: "btn btn-info mt-3" })
+.container
+  #item1.tab-pane.fade.show.active{"aria-labelledby" => "item1-tab", role: "tabpanel"}
+    %label.mt-3.mb-4(for="") ---プロフィール---
+    = form_with(model: @profile, class: "form-horizontal mb-3", local: true) do |f|
+      = render 'layouts/error_messages', model: f.object
+      .form-group
+        = f.label "メイン写真を設定する"
+        %br/
+        -# 編集前に画像が存在していれば編集画面に表示
+        - if current_user.profile.image?
+          = image_tag current_user.profile.image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
+        = f.file_field :image, class: "form-control-file"
+        %p
+          = f.check_box :remove_image #画像を削除するチェックボックスremove_カラム名
+          画像を削除する
+      .form-group
+        = f.label :VR, "VR画像を設定する"
+        %br/
+        -# 編集前に画像が存在していれば編集画面に表示
+        - if current_user.profile.sub_image?
+          = image_tag current_user.profile.sub_image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
+        = f.file_field :sub_image, class: "form-control-file"
+        %p
+          = f.check_box :remove_sub_image #画像を削除するチェックボックスremove_カラム名
+          画像を削除する
+      .form-group
+        -# カラム追加済み
+        = f.label "キャッチコピー"
+        = f.text_field :catch_copy, class: "form-control"
+      .form-group
+        = f.label "名字"
+        = f.text_field :first_name, class: "form-control"
+      .form-group
+        = f.label "名前"
+        = f.text_field :family_name, class: "form-control"
+      .form-group
+        = f.label "名字（ふりがな）"
+        = f.text_field :first_name_kana, class: "form-control"
+      .form-group
+        = f.label "名前（ふりがな）"
+        = f.text_field :family_name_kana, class: "form-control"
+      .form-group
+        = f.label "password"
+        = f.text_field :password, class: "form-control"
+      .form-group
+        = f.label "郵便番号 ※半角数字のみ（ハイフンなし）"
+        -# 半角数字のみ（ハイフンなし）
+        = f.text_field :post_code, class: "form-control", pattern: "^[0-9]+$"
+      .form-group
+        = f.label "都道府県"
+        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: "form-control"}
+      .form-group
+        = f.label "市区町村"
+        = f.text_field :city, class: "form-control"
+      .form-group
+        = f.label "以降の住所"
+        = f.text_field :address_number, class: "form-control"
+      .form-group
+        = f.label "建物"
+        = f.text_field :building, class: "form-control"
+      .form-group
+        = f.label "電話番号 ※半角数字のみ（ハイフンなし）"
+        = f.text_field :phone, class: "form-control", pattern: "^[0-9]+$"
+      .form-group
+        = f.label "生年月日"
+        = f.date_select :birth_date, {year_format: ->year { "#{Date.new(year, 12, 31).jisx0301.split('.').first}(#{year})" },use_month_numbers: true, start_year: 1950, end_year: Time.now.year, prompt: "---"}, {class: "form-control"}
+      .form-group
+        = f.label "小学校"
+        = f.text_field :primary_school, class: "form-control"
+      .form-group
+        = f.label "中学校"
+        = f.text_field :Junior_high_school, class: "form-control"
+      .form-group
+        = f.label "高校"
+        = f.text_field :high_school, class: "form-control"
+      .form-group
+        = f.label "大学"
+        = f.text_field :university, class: "form-control"
+      .form-group
+        = f.label "大学院"
+        = f.text_field :graduate_school, class: "form-control"
+      .form-group
+        = f.label "専門学校"
+        = f.text_field :vocational_school, class: "form-control"
+      .form-group
+        = f.label "その他学歴"
+        = f.text_field :other_school, class: "form-control"
+      .form-group
+        = f.label "職歴１"
+        = f.text_field :first_career, class: "form-control"
+      .form-group
+        = f.label "職歴２"
+        = f.text_field :second_career, class: "form-control"
+      .form-group
+        = f.label "職歴３"
+        = f.text_field :third_career, class: "form-control"
+      .form-group
+        = f.label "職歴４"
+        = f.text_field :fourth_career, class: "form-control"
+      .form-group
+        = f.label "職歴５"
+        = f.text_field :last_career, class: "form-control"
+      .form-group
+        = f.label "FaceBook"
+        = f.text_field :facebook, class: "form-control"
+      .form-group
+        = f.label "Twitter"
+        = f.text_field :twitter, class: "form-control"
+      .form-group
+        = f.label "ホームページ"
+        = f.text_field :hp, class: "form-control"
 
-        %label.mt-3.mb-4(for="") ---自己紹介---
+      %label.mt-3.mb-4(for="") ---自己紹介---
 
-        .form-group
-          = f.label "タイトル"
-          -# カラム追加済み
-          = f.text_field :avatar_title, class: "form-control"
-        .form-group
-          = f.label "キャッチコピー"
-          -# カラム追加済み
-          = f.text_field :avatar_catch_copy, class: "form-control"
-        .form-group
-          = f.label "紹介文"
-          = f.text_area :introduction, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
-        .form-group
-          = f.label "アバター写真"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.avatar?
-            = image_tag current_user.profile.avatar.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :avatar, class: "form-control-file"
-          %p
-            = f.check_box :remove_avatar #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          = f.label "写真についての説明文"
-          -# カラム追加済み
-          = f.text_area :avatar_about, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
+      .form-group
+        = f.label "タイトル"
+        -# カラム追加済み
+        = f.text_field :avatar_title, class: "form-control"
+      .form-group
+        = f.label "キャッチコピー"
+        -# カラム追加済み
+        = f.text_field :avatar_catch_copy, class: "form-control"
+      .form-group
+        = f.label "紹介文"
+        = f.text_area :introduction, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
+      .form-group
+        = f.label "アバター写真"
+        %br/
+        -# 編集前に画像が存在していれば編集画面に表示
+        - if current_user.profile.avatar?
+          = image_tag current_user.profile.avatar.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
+        = f.file_field :avatar, class: "form-control-file"
+        %p
+          = f.check_box :remove_avatar #画像を削除するチェックボックスremove_カラム名
+          画像を削除する
+      .form-group
+        = f.label "写真についての説明文"
+        -# カラム追加済み
+        = f.text_area :avatar_about, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
 
-        %button.btn.btn-secondary.mt-3.mb-4 自己紹介を追加する
+      %button.btn.btn-secondary.mt-3.mb-4 自己紹介を追加する
 
-        .form-group
-          = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
-          = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
-        -# ↓送信OK
+      .form-group
+        = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
+        = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
+      -# ↓送信OK
 
-        .form-group
-          = f.label "ギャラリー写真（同時に10枚までアップロードできます）"
-          #image-previews
-            - @profile.images.each_with_index do |image, i|
-              .preview( data-index = "#{i}" )
-                .preview__photo
-                  = image_tag image.src.url, data: { index: i }, class: "image-size"
-                .preview__button
-                  .preview__button--edit
-                    %button.btn.btn-outline-secondary.change-img(type="button")
-                      変更
-                  .preview__button--delete
-                    %button.btn.btn-outline-secondary.delete-img(type="button")
-                      削除
-
-          #image-box
-            = f.fields_for :images do |i|
-              .input-group.hiddenEdit( data-index = "#{i.index}" )
-                .js-file_group.custom-file( data-index = "#{i.index}" )
-                  = i.file_field :src, class: 'js-file custom-file-input'
-                  %label.custom-file-label{ for: "inputFile" }( data-browse="参照" )
-                    ここにファイル名
-                .input-group-append
-                  %button.btn.btn-outline-secondary.input-group-text(type="button")
+      .form-group
+        = f.label "ギャラリー写真（同時に10枚までアップロードできます）"
+        #image-previews
+          - @profile.images.each_with_index do |image, i|
+            .preview( data-index = "#{i}" )
+              .preview__photo
+                = image_tag image.src.url, data: { index: i }, class: "image-size"
+              .preview__button
+                .preview__button--edit
+                  %button.btn.btn-outline-secondary.change-img(type="button")
+                    変更
+                .preview__button--delete
+                  %button.btn.btn-outline-secondary.delete-img(type="button")
                     削除
-                - if @profile.persisted?
-                  = i.check_box :_destroy, data: { index: i.index }
-          #which-model
-        
-        = f.submit class: "btn btn-primary"
 
-    #item2.tab-pane.fade{"aria-labelledby" => "item2-tab", role: "tabpanel"}
-      %label.mt-3.mb-4(for="") ---店舗情報---
-      = form_with(model: @profile, class: "form-horizontal mb-3", local: true) do |f|
-        = render 'layouts/error_messages', model: f.object
-        .form-group
-          = f.label "メイン写真を設定する"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.store_image?
-            = image_tag current_user.profile.store_image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :store_image, class: "form-control-file"
-          %p
-            = f.check_box :remove_store_image #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          = f.label "店名"
-          = f.text_field :store_name, class: "form-control"
-        .form-group
-          = f.label "お店の紹介文"
-          = f.text_area :store_explanation, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
-        .form-group
-          = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
-          = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
-        -# ↓送信OK
+        #image-box
+          = f.fields_for :images do |i|
+            .input-group.hiddenEdit( data-index = "#{i.index}" )
+              .js-file_group.custom-file( data-index = "#{i.index}" )
+                = i.file_field :src, class: 'js-file custom-file-input'
+                %label.custom-file-label{ for: "inputFile" }( data-browse="参照" )
+                  ここにファイル名
+              .input-group-append
+                %button.btn.btn-outline-secondary.input-group-text(type="button")
+                  削除
+              - if @profile.persisted?
+                = i.check_box :_destroy, data: { index: i.index }
+        #which-model
+      
+      = f.submit class: "btn btn-primary"
 
-        -# .form-group
-        -#   = f.label "ギャラリー写真（同時に10枚までアップロードできます）"
-        -#   #image-previews
-        -#     - @profile.images.each_with_index do |image, i|
-        -#       .preview( data-index = "#{i}" )
-        -#         .preview__photo
-        -#           = image_tag image.src.url, data: { index: i }, class: "image-size"
-        -#         .preview__button
-        -#           .preview__button--edit
-        -#             %button.btn.btn-outline-secondary.change-img(type="button")
-        -#               変更
-        -#           .preview__button--delete
-        -#             %button.btn.btn-outline-secondary.delete-img(type="button")
-        -#               削除
-
-        -#   #image-box
-        -#     = f.fields_for :images do |i|
-        -#       .input-group.hiddenEdit( data-index = "#{i.index}" )
-        -#         .js-file_group.custom-file( data-index = "#{i.index}" )
-        -#           = i.file_field :src, class: 'js-file custom-file-input'
-        -#           %label.custom-file-label{ for: "inputFile" }( data-browse="参照" )
-        -#             ここにファイル名
-        -#         .input-group-append
-        -#           %button.btn.btn-outline-secondary.input-group-text(type="button")
-        -#             削除
-        -#         - if @profile.persisted?
-        -#           = i.check_box :_destroy, data: { index: i.index }
-
-        = f.submit class: "btn btn-primary"
-
-    #item3.tab-pane.fade{"aria-labelledby" => "item3-tab", role: "tabpanel"}
-      %label.mt-3.mb-4(for="") ---商品情報---
-      = form_with(model: @profile, class: "form-horizontal mb-3", local: true) do |f|
-        = render 'layouts/error_messages', model: f.object
-        .form-group
-          = f.label "メイン写真を設定する"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.item_image?
-            = image_tag current_user.profile.item_image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :item_image, class: "form-control-file"
-          %p
-            = f.check_box :remove_item_image #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          -# カラム追加済み
-          = f.label "商品名"
-          = f.text_field :item_name, class: "form-control"
-        .form-group
-          = f.label "商品の紹介文"
-          = f.text_area :item_explanation, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
-        .form-group
-          = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
-          = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
-        -# ↓送信OK
-
-        -# .form-group
-        -#   = f.label "ギャラリー写真（同時に10枚までアップロードできます）"
-        -#   #image-previews
-        -#     - @profile.images.each_with_index do |image, i|
-        -#       .preview( data-index = "#{i}" )
-        -#         .preview__photo
-        -#           = image_tag image.src.url, data: { index: i }, class: "image-size"
-        -#         .preview__button
-        -#           .preview__button--edit
-        -#             %button.btn.btn-outline-secondary.change-img(type="button")
-        -#               変更
-        -#           .preview__button--delete
-        -#             %button.btn.btn-outline-secondary.delete-img(type="button")
-        -#               削除
-
-        -#   #image-box
-        -#     = f.fields_for :images do |i|
-        -#       .input-group.hiddenEdit( data-index = "#{i.index}" )
-        -#         .js-file_group.custom-file( data-index = "#{i.index}" )
-        -#           = i.file_field :src, class: 'js-file custom-file-input'
-        -#           %label.custom-file-label{ for: "inputFile" }( data-browse="参照" )
-        -#             ここにファイル名
-        -#         .input-group-append
-        -#           %button.btn.btn-outline-secondary.input-group-text(type="button")
-        -#             削除
-        -#         - if @profile.persisted?
-        -#           = i.check_box :_destroy, data: { index: i.index }
-
-        = f.submit class: "btn btn-primary"
-
-    #item4.tab-pane.fade{"aria-labelledby" => "item4-tab", role: "tabpanel"}
-      %label.mt-3.mb-4(for="") ---サービス---
-      = form_with(model: @profile, class: "form-horizontal mb-3", local: true) do |f|
-        = render 'layouts/error_messages', model: f.object
-        .form-group
-          = f.label "メイン写真を設定する"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.service_image?
-            = image_tag current_user.profile.service_image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :service_image, class: "form-control-file"
-          %p
-            = f.check_box :remove_service_image #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          = f.label "サービスの名称"
-          = f.text_field :service_name, class: "form-control"
-        .form-group
-          = f.label "サービスの紹介文"
-          = f.text_area :service_explanation, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
-        .form-group
-          = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
-          = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
-        -# ↓送信OK
-
-        -# .form-group
-        -#   = f.label "ギャラリー写真（同時に10枚までアップロードできます）"
-        -#   #image-previews
-        -#     - @profile.images.each_with_index do |image, i|
-        -#       .preview( data-index = "#{i}" )
-        -#         .preview__photo
-        -#           = image_tag image.src.url, data: { index: i }, class: "image-size"
-        -#         .preview__button
-        -#           .preview__button--edit
-        -#             %button.btn.btn-outline-secondary.change-img(type="button")
-        -#               変更
-        -#           .preview__button--delete
-        -#             %button.btn.btn-outline-secondary.delete-img(type="button")
-        -#               削除
-
-        -#   #image-box
-        -#     = f.fields_for :images do |i|
-        -#       .input-group.hiddenEdit( data-index = "#{i.index}" )
-        -#         .js-file_group.custom-file( data-index = "#{i.index}" )
-        -#           = i.file_field :src, class: 'js-file custom-file-input'
-        -#           %label.custom-file-label{ for: "inputFile" }( data-browse="参照" )
-        -#             ここにファイル名
-        -#         .input-group-append
-        -#           %button.btn.btn-outline-secondary.input-group-text(type="button")
-        -#             削除
-        -#         - if @profile.persisted?
-        -#           = i.check_box :_destroy, data: { index: i.index }
-        = f.submit class: "btn btn-primary"
-
-    #item5.tab-pane.fade{"aria-labelledby" => "item5-tab", role: "tabpanel"}
-      %label.mt-3.mb-4(for="") ---イベント---
-      = form_with(model: @profile, class: "form-horizontal mb-3", local: true) do |f|
-        = render 'layouts/error_messages', model: f.object
-        .form-group
-          = f.label "メイン写真を設定する"
-          %br/
-          -# 編集前に画像が存在していれば編集画面に表示
-          - if current_user.profile.event_image?
-            = image_tag current_user.profile.event_image.url(:thumb), class: "thumb mb-2", style: "border:solid 1px #ccc;padding:4px"
-          = f.file_field :event_image, class: "form-control-file"
-          %p
-            = f.check_box :remove_event_image #画像を削除するチェックボックスremove_カラム名
-            画像を削除する
-        .form-group
-          = f.label "イベント名"
-          = f.text_field :event_name, class: "form-control"
-        .form-group
-          = f.label "開催場所"
-          = f.text_field :event_place, class: "form-control"
-        .form-group
-          = f.label "開催日時"
-          %br/
-          = f.datetime_select :event_start, start_year: now.year, end_year: now.year + 1, use_month_numbers: true, include_blank: true, date_separator: " / "
-        .form-group
-          = f.label "終了日時"
-          %br/
-          = f.datetime_select :event_end, start_year: now.year, end_year: now.year + 1, use_month_numbers: true, include_blank: true, date_separator: " / "
-        .form-group
-          = f.label "イベントの説明"
-          = f.text_area :event_explanation, class: "form-control", row: 5, maxlength: "500", placeholder: "500文字まで"
-        .form-group
-          = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
-          = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
-        -# ↓送信OK
-
-        -# .form-group
-        -#   = f.label "ギャラリー写真（同時に10枚までアップロードできます）"
-        -#   #image-previews
-        -#     - @profile.images.each_with_index do |image, i|
-        -#       .preview( data-index = "#{i}" )
-        -#         .preview__photo
-        -#           = image_tag image.src.url, data: { index: i }, class: "image-size"
-        -#         .preview__button
-        -#           .preview__button--edit
-        -#             %button.btn.btn-outline-secondary.change-img(type="button")
-        -#               変更
-        -#           .preview__button--delete
-        -#             %button.btn.btn-outline-secondary.delete-img(type="button")
-        -#               削除
-
-        -#   #image-box
-        -#     = f.fields_for :images do |i|
-        -#       .input-group.hiddenEdit( data-index = "#{i.index}" )
-        -#         .js-file_group.custom-file( data-index = "#{i.index}" )
-        -#           = i.file_field :src, class: 'js-file custom-file-input'
-        -#           %label.custom-file-label{ for: "inputFile" }( data-browse="参照" )
-        -#             ここにファイル名
-        -#         .input-group-append
-        -#           %button.btn.btn-outline-secondary.input-group-text(type="button")
-        -#             削除
-        -#         - if @profile.persisted?
-        -#           = i.check_box :_destroy, data: { index: i.index }
-        = f.submit class: "btn btn-primary"

--- a/app/views/profiles/index.html.haml
+++ b/app/views/profiles/index.html.haml
@@ -29,6 +29,12 @@
 - elsif current_user.profile.user_id == current_user.id
   = link_to "プロフィール編集", edit_profile_path(current_user.profile.id)
 
+-# 仮に各テーブルindexへのリンクを置きます
+= link_to "店舗一覧", store_profiles_path
+= link_to "商品一覧", item_profiles_path
+= link_to "サービス一覧", service_profiles_path
+= link_to "イベント一覧", event_profiles_path
+
 -# 検索画面へのリンク
 = link_to "ユーザー検索",search_users_path
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -70,3 +70,106 @@
         #{@profile.fourth_career}
       %p.h5.text-center.m-4
         #{@profile.last_career}
+  %hr.my-4
+  - if @store_profiles.present?
+    %p.h5.text-center.m-4
+      店舗情報一覧
+    .row
+      - @store_profiles.each do |store_profile|
+        .col-lg-4
+          .card.mb-3
+            - if store_profile.image.present?
+              = image_tag(store_profile.image.url, alt: "メイン写真", class: "card-img-top no_image")
+            - else
+              %img.card-img-top{alt: "...", src: "/assets/no_image.png"}/
+            .card-body{style: "height: 276px; position: relative;"}
+              %h5.card-title
+                = store_profile.name
+              .small.text-muted
+                = "投稿者：#{store_profile.user.nickname}"
+              .small.text-muted{style: "margin-bottom: 12px"}
+                = "最終更新：#{time_ago_in_words(store_profile.updated_at)}前"
+              %p.card-text{style: "height: 72px"}
+                = store_profile.explanation.truncate(45)
+              %div{style: "position: absolute; left: 20px; bottom: 20px"}
+                = link_to("クリックして詳細へ", store_profile_path(store_profile.id), { class: "btn btn-primary mt-3" })
+    -# %div
+    -#   = paginate @store_profiles, theme: 'twitter-bootstrap-4'
+  - if @item_profiles.present?
+    %p.h5.text-center.m-4
+      商品情報一覧
+    .row
+      - @item_profiles.each do |item_profile|
+        .col-lg-4
+          .card.mb-3
+            - if item_profile.image.present?
+              = image_tag(item_profile.image.url, alt: "メイン写真", class: "card-img-top no_image")
+            - else
+              %img.card-img-top{alt: "...", src: "/assets/no_image.png"}/
+            .card-body{style: "height: 276px; position: relative;"}
+              %h5.card-title
+                = item_profile.name
+              .small.text-muted
+                = "投稿者：#{item_profile.user.nickname}"
+              .small.text-muted{style: "margin-bottom: 12px"}
+                = "最終更新：#{time_ago_in_words(item_profile.updated_at)}前"
+              %p.card-text{style: "height: 72px"}
+                = item_profile.explanation.truncate(45)
+              %div{style: "position: absolute; left: 20px; bottom: 20px"}
+                = link_to("クリックして詳細へ", item_profile_path(item_profile.id), { class: "btn btn-primary mt-3" })
+    -# %div
+    -#   = paginate @item_profiles, theme: 'twitter-bootstrap-4'
+  - if @service_profiles.present?
+    %p.h5.text-center.m-4
+      サービス情報一覧
+    .row
+      - @service_profiles.each do |service_profile|
+        .col-lg-4
+          .card.mb-3
+            - if service_profile.image.present?
+              = image_tag(service_profile.image.url, alt: "メイン写真", class: "card-img-top no_image")
+            - else
+              %img.card-img-top{alt: "...", src: "/assets/no_image.png"}/
+            .card-body{style: "height: 276px; position: relative;"}
+              %h5.card-title
+                = service_profile.name
+              .small.text-muted
+                = "投稿者：#{service_profile.user.nickname}"
+              .small.text-muted{style: "margin-bottom: 12px"}
+                = "最終更新：#{time_ago_in_words(service_profile.updated_at)}前"
+              %p.card-text{style: "height: 72px"}
+                = service_profile.explanation.truncate(45)
+              %div{style: "position: absolute; left: 20px; bottom: 20px"}
+                = link_to("クリックして詳細へ", service_profile_path(service_profile.id), { class: "btn btn-primary mt-3" })
+    -# %div
+    -#   = paginate @service_profiles, theme: 'twitter-bootstrap-4'
+  - if @event_profiles.present?
+    %p.h5.text-center.m-4
+      イベント情報一覧
+    .row
+      - @event_profiles.each do |event_profile|
+        .col-lg-4
+          .card.mb-3
+            - if event_profile.image.present?
+              = image_tag(event_profile.image.url, alt: "メイン写真", class: "card-img-top no_image")
+            - else
+              %img.card-img-top{alt: "...", src: "/assets/no_image.png"}/
+            .card-body{style: "height: 295px; position: relative;"}
+              %h5.card-title
+                = event_profile.title
+              .small.text-muted
+                = "投稿者：#{event_profile.user.nickname}"
+              .small.text-muted{style: "margin-bottom: 12px"}
+                = "最終更新：#{time_ago_in_words(event_profile.updated_at)}前"
+              %p.card-text{style: "height: 72px; margin-bottom: 0.75rem;"}
+                = event_profile.explanation.truncate(45)
+              - if event_profile.start.present?
+                %p.card-text{style: "margin-bottom: 0.75rem;"}
+                  %small.text-muted
+                    開始予定 :
+                  %small.text-muted
+                    = event_profile.start.strftime("%Y-%m-%d %H:%M")
+              %div{style: "position: absolute; left: 20px; bottom: 20px"}
+                = link_to("クリックして詳細へ", event_profile_path(event_profile.id), { class: "btn btn-primary mt-3" })
+    -# %div
+    -#   = paginate @event_profiles, theme: 'twitter-bootstrap-4'

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
 
 "@babel/core@^7.7.2":
-  version "7.12.7"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.7.tgz#bf55363c08c8352a37691f7216ec30090bf7e3bf"
-  integrity sha512-tRKx9B53kJe8NCGGIxEQb2Bkr0riUIEuN7Sc1fxhs5H8lKlCWUvQCSNMVIB0Meva7hcbCRJ76de15KoLltdoqw==
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
+  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.12.5"
@@ -25,7 +25,7 @@
     "@babel/helpers" "^7.12.5"
     "@babel/parser" "^7.12.7"
     "@babel/template" "^7.12.7"
-    "@babel/traverse" "^7.12.7"
+    "@babel/traverse" "^7.12.9"
     "@babel/types" "^7.12.7"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
@@ -801,10 +801,10 @@
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
 
-"@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.12.7":
-  version "7.12.7"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.7.tgz#572a722408681cef17d6b0bef69ef2e728ca69f1"
-  integrity sha512-nMWaqsQEeSvMNypswUDzjqQ+0rR6pqCtoQpsqGJC4/Khm9cISwPTSpai57F6/jDaOoEGz8yE/WxcO3PV6tKSmQ==
+"@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.12.9":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.9.tgz#fad26c972eabbc11350e0b695978de6cc8e8596f"
+  integrity sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.12.5"
@@ -917,9 +917,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
-  integrity sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==
+  version "14.14.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
+  integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1353,14 +1353,13 @@ aws4@^1.8.0:
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 babel-loader@^8.0.6:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.1.tgz#e53313254677e86f27536f5071d807e01d24ec00"
-  integrity sha512-dMF8sb2KQ8kJl21GUjkW1HWmcsL39GOV5vnzjqrCzEPNY0S0UfMLnumidiwIajDSBmKhYf5iRW+HXaM4cvCKBw==
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz#9363ce84c10c9a40e6c753748e1441b60c8a0b81"
+  integrity sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==
   dependencies:
-    find-cache-dir "^2.1.0"
+    find-cache-dir "^3.3.1"
     loader-utils "^1.4.0"
-    make-dir "^2.1.0"
-    pify "^4.0.1"
+    make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
 babel-plugin-dynamic-import-node@^2.3.0, babel-plugin-dynamic-import-node@^2.3.3:
@@ -1588,7 +1587,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.14.6, browserslist@^4.6.4:
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.14.7, browserslist@^4.6.4:
   version "4.14.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.7.tgz#c071c1b3622c1c2e790799a37bb09473a4351cb6"
   integrity sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==
@@ -1782,9 +1781,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157:
-  version "1.0.30001159"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
-  integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
+  version "1.0.30001161"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz#64f7ffe79ee780b8c92843ff34feb36cea4651e0"
+  integrity sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==
 
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.3.0"
@@ -2103,17 +2102,17 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.7.0.tgz#8479c5d3d672d83f1f5ab94cf353e57113e065ed"
-  integrity sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.0.tgz#3248c6826f4006793bd637db608bca6e4cd688b1"
+  integrity sha512-o9QKelQSxQMYWHXc/Gc4L8bx/4F7TTraE5rhuN8I7mKBt5dBIUpXpIR3omv70ebr8ST5R3PqbDQr+ZI3+Tt1FQ==
   dependencies:
-    browserslist "^4.14.6"
+    browserslist "^4.14.7"
     semver "7.0.0"
 
 core-js@^3.4.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.7.0.tgz#b0a761a02488577afbf97179e4681bf49568520f"
-  integrity sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.0.tgz#0fc2d4941cadf80538b030648bb64d230b4da0ce"
+  integrity sha512-W2VYNB0nwQQE7tKS7HzXd7r2y/y2SVJl4ga6oH/dnaLFzM0o2lB2P3zCkWj5Wc/zyMYjtgd5Hmhk0ObkQFZOIA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2285,10 +2284,10 @@ css-tree@1.0.0-alpha.37:
     mdn-data "2.0.4"
     source-map "^0.6.1"
 
-css-tree@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.1.tgz#30b8c0161d9fb4e9e2141d762589b6ec2faebd2e"
-  integrity sha512-NVN42M2fjszcUNpDbdkvutgQSlFYsr1z7kqeuCagHnNLBfYor6uP1WL1KrkmdYZ5Y1vTBCIOI/C/+8T98fJ71w==
+css-tree@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
+  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
@@ -2382,11 +2381,11 @@ cssnano@^4.1.10:
     postcss "^7.0.0"
 
 csso@^4.0.2:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.1.1.tgz#e0cb02d6eb3af1df719222048e4359efd662af13"
-  integrity sha512-Rvq+e1e0TFB8E8X+8MQjHSY6vtol45s5gxtLI/018UsAn2IBMmwNEZRM/h+HVnAJRHjasLIKKUO3uvoMM28LvA==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
+  integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
-    css-tree "^1.0.0"
+    css-tree "^1.1.2"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -2629,9 +2628,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.591:
-  version "1.3.603"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz#1b71bec27fb940eccd79245f6824c63d5f7e8abf"
-  integrity sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==
+  version "1.3.610"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.610.tgz#1254eb394acd220a836ea1f203f8cded4e487052"
+  integrity sha512-eFDC+yVQpEhtlapk4CYDPfV9ajF9cEof5TBcO49L1ETO+aYogrKWDmYpZyxBScMNe8Bo/gJamH4amQ4yyvXg4g==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -3787,9 +3786,9 @@ is-color-stop@^1.0.0:
     rgba-regex "^1.0.0"
 
 is-core-module@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
-  integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   dependencies:
     has "^1.0.3"
 
@@ -4246,9 +4245,9 @@ lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.1
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 loglevel@^1.6.8:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
-  integrity sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
+  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -4280,7 +4279,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^2.0.0, make-dir@^2.1.0:
+make-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
@@ -4288,7 +4287,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.2:
+make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -4806,12 +4805,12 @@ object-inspect@^1.8.0:
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
 object-is@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.3.tgz#2e3b9e65560137455ee3bd62aec4d90a2ea1cc81"
-  integrity sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
+  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -4836,12 +4835,13 @@ object.assign@^4.1.0, object.assign@^4.1.1:
     object-keys "^1.1.1"
 
 object.getownpropertydescriptors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz#0dfda8d108074d9c563e80490c883b6661091544"
+  integrity sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -4851,13 +4851,13 @@ object.pick@^1.3.0:
     isobject "^3.0.1"
 
 object.values@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
-  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz#7a2015e06fcb0f546bd652486ce8583a4731c731"
+  integrity sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
 obuf@^1.0.0, obuf@^1.1.2:


### PR DESCRIPTION
# what
- マイページに自分の投稿一覧を表示
- カード情報があるかどうかで新規投稿を分岐
- 仮にトップページに各テーブル一覧へのリンク張ってます
- 各テーブルから他ユーザーの投稿のshowに飛び、「投稿者のプロフィール」をクリックすると、「パスワードが一致しません」のフラッシュメッセージが出て進めません。「プロフィール閲覧にはパスワード入力が必要です。」の画面を挟んでもらえると助かります
- ページネーションはスマホサイズでうまく表示されなかったので保留