### PR TITLE
ページネーションの実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -138,6 +138,16 @@
 
 
 @media (max-width: 979px){
+  // ページネーション用
+  .paginate {
+    nav {
+      visibility: visible;
+      opacity: 1;
+      position: unset;
+    }
+  }
+  // ここまで
+
   .title {
     font-size: 40px;
   }

--- a/app/controllers/event_profiles_controller.rb
+++ b/app/controllers/event_profiles_controller.rb
@@ -1,6 +1,6 @@
 class EventProfilesController < ApplicationController
   def index
-    @event_profiles = EventProfile.includes(:user).order(updated_at: :DESC)
+    @event_profiles = EventProfile.includes(:user).order(updated_at: :DESC).page(params[:page]).per(9)
   end
   def new
     @event_profile = EventProfile.new

--- a/app/controllers/item_profiles_controller.rb
+++ b/app/controllers/item_profiles_controller.rb
@@ -1,6 +1,6 @@
 class ItemProfilesController < ApplicationController
   def index
-    @item_profiles = ItemProfile.includes(:user).order(updated_at: :DESC)
+    @item_profiles = ItemProfile.includes(:user).order(updated_at: :DESC).page(params[:page]).per(9)
   end
   def new
     @item_profile = ItemProfile.new

--- a/app/controllers/service_profiles_controller.rb
+++ b/app/controllers/service_profiles_controller.rb
@@ -1,6 +1,6 @@
 class ServiceProfilesController < ApplicationController
   def index
-    @service_profiles = ServiceProfile.includes(:user).order(updated_at: :DESC)
+    @service_profiles = ServiceProfile.includes(:user).order(updated_at: :DESC).page(params[:page]).per(9)
   end
   def new
     @service_profile = ServiceProfile.new

--- a/app/controllers/store_profiles_controller.rb
+++ b/app/controllers/store_profiles_controller.rb
@@ -1,6 +1,6 @@
 class StoreProfilesController < ApplicationController
   def index
-    @store_profiles = StoreProfile.includes(:user).order(updated_at: :DESC)
+    @store_profiles = StoreProfile.includes(:user).order(updated_at: :DESC).page(params[:page]).per(9)
   end
   def new
     @store_profile = StoreProfile.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,14 +57,14 @@ class UsersController < ApplicationController
     # タグ全部取ってきます
     @tag_list = Tag.all
 
-    # @store_profiles = @user.store_profiles.order("created_at DESC").page(params[:page]).per(3)
-    # @item_profiles = @user.item_profiles.order("created_at DESC").page(params[:page]).per(3)
-    # @service_profiles = @user.service_profiles.order("created_at DESC").page(params[:page]).per(3)
-    # @event_profiles = @user.event_profiles.order("created_at DESC").page(params[:page]).per(3)
-    @store_profiles = @user.store_profiles.order("created_at DESC")
-    @item_profiles = @user.item_profiles.order("created_at DESC")
-    @service_profiles = @user.service_profiles.order("created_at DESC")
-    @event_profiles = @user.event_profiles.order("created_at DESC")
+    @store_profiles = @user.store_profiles.order("created_at DESC").page(params[:page]).per(3)
+    @item_profiles = @user.item_profiles.order("created_at DESC").page(params[:page]).per(3)
+    @service_profiles = @user.service_profiles.order("created_at DESC").page(params[:page]).per(3)
+    @event_profiles = @user.event_profiles.order("created_at DESC").page(params[:page]).per(3)
+    # @store_profiles = @user.store_profiles.order("created_at DESC")
+    # @item_profiles = @user.item_profiles.order("created_at DESC")
+    # @service_profiles = @user.service_profiles.order("created_at DESC")
+    # @event_profiles = @user.event_profiles.order("created_at DESC")
 
   end
   
@@ -87,12 +87,12 @@ class UsersController < ApplicationController
     if params[:q].present?
       # 検索フォームからアクセスした時の処理
       @user_search = User.ransack(search_params)
-      @users = @user_search.result(distinct: true).includes(:profile)
+      @users = @user_search.result(distinct: true).includes(:profile).page(params[:page]).per(10)
     else
       # 検索フォーム外からアクセスした時の処理
       params[:q] = { sorts: 'id desc' }
       @user_search = User.ransack()
-      @users = User.all.includes(:profile)
+      @users = User.all.includes(:profile).page(params[:page]).per(10)
     end
 
   end

--- a/app/views/event_profiles/index.html.haml
+++ b/app/views/event_profiles/index.html.haml
@@ -45,3 +45,7 @@
                   = event_profile.start.strftime("%Y-%m-%d %H:%M")
             %div{style: "position: absolute; left: 20px; bottom: 20px"}
               = link_to("クリックして詳細へ", event_profile_path(event_profile.id), { class: "btn btn-primary mt-3" })
+  %p
+    = page_entries_info @event_profiles
+  .paginate.mb-4
+    = paginate @event_profiles

--- a/app/views/item_profiles/index.html.haml
+++ b/app/views/item_profiles/index.html.haml
@@ -39,3 +39,7 @@
               = item_profile.explanation.truncate(45)
             %div{style: "position: absolute; left: 20px; bottom: 20px"}
               = link_to("クリックして詳細へ", item_profile_path(item_profile.id), { class: "btn btn-primary mt-3" })
+  %p
+    = page_entries_info @item_profiles
+  .paginate.mb-4
+    = paginate @item_profiles

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
+- else
+  %li.page-item
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,12 @@
+= paginator.render do
+  %nav
+    %ul.pagination
+      = first_page_tag unless current_page.first?
+      = prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          = page_tag page
+        - elsif !page.was_truncated?
+          = gap_tag
+      = next_page_tag unless current_page.last?
+      = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/service_profiles/index.html.haml
+++ b/app/views/service_profiles/index.html.haml
@@ -39,3 +39,7 @@
               = service_profile.explanation.truncate(45)
             %div{style: "position: absolute; left: 20px; bottom: 20px"}
               = link_to("クリックして詳細へ", service_profile_path(service_profile.id), { class: "btn btn-primary mt-3" })
+  %p
+    = page_entries_info @service_profiles
+  .paginate.mb-4
+    = paginate @service_profiles

--- a/app/views/store_profiles/index.html.haml
+++ b/app/views/store_profiles/index.html.haml
@@ -39,3 +39,7 @@
               = store_profile.explanation.truncate(45)
             %div{style: "position: absolute; left: 20px; bottom: 20px"}
               = link_to("クリックして詳細へ", store_profile_path(store_profile.id), { class: "btn btn-primary mt-3" })
+  %p
+    = page_entries_info @store_profiles
+  .paginate.mb-4
+    = paginate @store_profiles

--- a/app/views/users/search.html.haml
+++ b/app/views/users/search.html.haml
@@ -65,3 +65,7 @@
             %span.show_tag
               = tag
         %hr.my-4{style: "width:97%; height:1px; background-color:#fefefe;"}/
+  %p
+    = page_entries_info @users
+  .paginate.mb-4
+    = paginate @users

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -93,8 +93,10 @@
                 = store_profile.explanation.truncate(45)
               %div{style: "position: absolute; left: 20px; bottom: 20px"}
                 = link_to("クリックして詳細へ", store_profile_path(store_profile.id), { class: "btn btn-primary mt-3" })
-    -# %div
-    -#   = paginate @store_profiles, theme: 'twitter-bootstrap-4'
+    %p
+      = page_entries_info @store_profiles
+    .paginate.mb-4
+      = paginate @store_profiles
   - if @item_profiles.present?
     %p.h5.text-center.m-4
       商品情報一覧
@@ -117,8 +119,10 @@
                 = item_profile.explanation.truncate(45)
               %div{style: "position: absolute; left: 20px; bottom: 20px"}
                 = link_to("クリックして詳細へ", item_profile_path(item_profile.id), { class: "btn btn-primary mt-3" })
-    -# %div
-    -#   = paginate @item_profiles, theme: 'twitter-bootstrap-4'
+    %p
+      = page_entries_info @item_profiles
+    .paginate.mb-4
+      = paginate @item_profiles
   - if @service_profiles.present?
     %p.h5.text-center.m-4
       サービス情報一覧
@@ -141,8 +145,10 @@
                 = service_profile.explanation.truncate(45)
               %div{style: "position: absolute; left: 20px; bottom: 20px"}
                 = link_to("クリックして詳細へ", service_profile_path(service_profile.id), { class: "btn btn-primary mt-3" })
-    -# %div
-    -#   = paginate @service_profiles, theme: 'twitter-bootstrap-4'
+    %p
+      = page_entries_info @service_profiles
+    .paginate.mb-4
+      = paginate @service_profiles
   - if @event_profiles.present?
     %p.h5.text-center.m-4
       イベント情報一覧
@@ -171,5 +177,7 @@
                     = event_profile.start.strftime("%Y-%m-%d %H:%M")
               %div{style: "position: absolute; left: 20px; bottom: 20px"}
                 = link_to("クリックして詳細へ", event_profile_path(event_profile.id), { class: "btn btn-primary mt-3" })
-    -# %div
-    -#   = paginate @event_profiles, theme: 'twitter-bootstrap-4'
+    %p
+      = page_entries_info @event_profiles
+    .paginate.mb-4
+      = paginate @event_profiles

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -26,7 +26,7 @@ ja:
         unlock_token: ロック解除用トークン
         updated_at: 更新日
     models:
-      user: ユーザ
+      # user: ユーザ
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -6,3 +6,13 @@ ja:
       previous: "&lsaquo; 前"
       next: "次 &rsaquo;"
       truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "No %{entry_name} found"
+          one: "Displaying <b>1</b> %{entry_name}"
+          other: "Displaying <b>all %{count}</b> %{entry_name}"
+      more_pages:
+        display_entries: "Displaying <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+        # display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"


### PR DESCRIPTION
# what
- 実装箇所
  - 検索ページ（10件ごと）
  - 各テーブル（6件ごと）
  - マイページ（3件ごと）
- なお、ページネーションはクリックするとページが切り替わる仕様のため、以下の状況下では思い通りの動作をしません。
  - マイページ（usersのshowアクション）
  - 同じページに複数箇所、ページネーション用のボタンがある
  - 自身が投稿した店舗10件、商品1件、サービス2件、イベント6件
  - この場合、ページネーションが表示されるのは店舗とイベント
  - 店舗のところに表示されているページネーションで2ページ目へのリンクをクリックすると、page2に遷移した際には店舗の4〜6件目、イベントの4〜6件目が表示され、商品とサービスは表示されない
- マイページのページネーション条件（3件）を増やしたほうが良さそうでしたらお知らせください
- レスポンシブ対応OK（表示されない理由はCSSが関係していました）