### PR TITLE
タグ作成に関する修正

### DIFF
--- a/app/assets/javascripts/bootstrap-tagsinput.js
+++ b/app/assets/javascripts/bootstrap-tagsinput.js
@@ -17,7 +17,7 @@
     freeInput: true,
     addOnBlur: true,
     maxTags: undefined,
-    maxChars: undefined,
+    maxChars: 15,
     confirmKeys: [13, 44],
     delimiter: ',',
     delimiterRegex: null,

--- a/app/assets/javascripts/enter.js
+++ b/app/assets/javascripts/enter.js
@@ -1,0 +1,8 @@
+// enterキーを押下するとsubmitされてしまうのを防ぐスクリプト
+// textareaは改行可能
+// tagがenterで区切ることができるようになる
+  $(function() {
+    $(document).on("keypress", "input:not(.allow_submit)", function(event) {
+      return event.which !== 13;
+    });
+  });

--- a/app/assets/stylesheets/bootstrap-tagsinput.scss
+++ b/app/assets/stylesheets/bootstrap-tagsinput.scss
@@ -32,7 +32,9 @@
   background-color: transparent;
   padding: 0 6px;
   margin: 0;
-  width: auto;
+  // width: auto;
+  // 入力時のwidth調整
+  width: 200px;
   max-width: inherit;
 }
 .bootstrap-tagsinput.form-control input::-moz-placeholder {

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -160,7 +160,7 @@
       %button.btn.btn-secondary.mt-3.mb-4 自己紹介を追加する
 
       .form-group
-        = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
+        = f.label "タグ（複数つける場合はEnterキーを押すか半角カンマで区切ってください）"
         = f.text_field :tag_ids, class: "form-control", id: "tag_ids", value: @tag_list, data: {role: "tagsinput"} 
       -# ↓送信OK
 

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -136,7 +136,7 @@
     %button.btn.btn-secondary.mt-3.mb-4 自己紹介を追加する
 
     .form-group
-      = f.label "タグ（複数つける場合は半角カンマで区切ってください）"
+      = f.label "タグ（複数つける場合はEnterキーを押すか半角カンマで区切ってください）"
       = f.text_field :tag_ids, class: "form-control", id: "tag_ids", data: {role: "tagsinput"} 
 
 


### PR DESCRIPTION
# what
- タグ入力時に3文字ほどで表示が見切れる→widthを200pxに変更
- 半角カンマでタグを区切るのがめんどくさかったのでenterキー押下で区切れるように変更（クリックしないとsubmitできないようにJSで制御しています。textareaはenterで改行できます）
- タグは15文字までで文字数制限しています

# why
- 使いやすさ向上